### PR TITLE
Added getpath.py and listmemberswithpath.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following python libraries are used:
 * netrc
 * subprocess
 * platform
-* argeparse
+* argparse
 
 
 ### Installing
@@ -38,9 +38,9 @@ Please use the installation intructions in the file INSTALL.md  [INSTALL.md](INS
 
 The pyviya tools use the sas-admin auth CLI to authenticate to Viya. To use the tool you must create a profile and authenticate. 
 
-This process is documented in the SAS Viya Administration guide here.
-
-http://documentation.sas.com/?cdcId=calcdc&cdcVersion=3.3&docsetId=calcli&docsetTarget=n1e2dehluji7jon1gk69yggc6i28.htm&locale=en
+This process is documented in the SAS Viya Administration guide here:  
+Viya 3.3: http://documentation.sas.com/?cdcId=calcdc&cdcVersion=3.3&docsetId=calcli&docsetTarget=n1e2dehluji7jon1gk69yggc6i28.htm&locale=en  
+Viya 3.4: http://documentation.sas.com/?cdcId=calcdc&cdcVersion=3.4&docsetId=calcli&docsetTarget=n1e2dehluji7jon1gk69yggc6i28.htm&locale=en  
 
 #### Creating a Profile and Logging on
 
@@ -102,6 +102,8 @@ Additional tools provide more complex functionality by combining multiple calls 
 * **updatedomain.py** Load a set of userids and passwords to a Viya domain from a csv file
 * **createfolders.py** Create a set of Viya folders from a csv file 
 * **explainaccess.py** Explains access for a folder, object or service endpoint
+* **getpath.py** Return path of folder, report, or other object in folder
+* **listmemberswithpath.py** lists members of a folder, recursively if desired
 
 Check back for additional tools and if you build a tool feel free to contribute it to the collection.
                    
@@ -229,10 +231,20 @@ FORMAT OF CSV file folder path (parents must exist), description
 *./explainaccess.py -u /SASEnvironmentManager/dashboard --header -l read update delete secure add remove create*
 
 \#Explain direct and indirect permissions on a report, reducing the permissions reported to just read, update, delete and secure, since none of add, remove or create are applicable to a report.   
-*./explainaccess.py -u /reports/reports/*folder_id *--header -l read update delete secure*
+*./explainaccess.py -u /reports/reports/id --header -l read update delete secure*
 
 \#Explain direct and indirect permissions on a folder expressed as a URI. Keep the default permissions list, but for completeness we must also specify -c true to request conveyed permissions be displayed, as they are not displayed by default for URIs.   
-*./explainaccess.py -u /folders/folders/*folder_id *--header -p -c true*
+*./explainaccess.py -u /folders/folders/id --header -p -c true*
+
+\# Get folder path for an object (can be a folder, report or any other object which has a folder path)  
+*./getpath.py -u /folders/folders/id*  
+*./getpath.py -u /reports/reports/id*  
+
+\# Return list of members of a folder identified by objectURI  
+*./listmemberswithpath.py -u /folders/folders/id*  
+
+\# Return list of all members of a folder identified by objectURI, recursively searching subfolders  
+*./listmemberswithpath.py -u /folders/folders/id -r*
 
 **Troubleshooting**
 

--- a/getpath.py
+++ b/getpath.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# getpath.py
+# January 2019
+#
+# Usage:
+# getpath.py -u objectURI [-d]
+#
+# Examples:
+#
+# 1. Return path of folder identified by objectURI
+#        ./getpath.py -u /folders/folders/060c0ea4-07ee-43ea-aa79-a1696b7f8f52
+#
+# 2. Return path of report identified by objectURI
+#        ./getpath.py -u /reports/reports/43de1f98-d7ef-4490-bb46-cc177f995052
+#
+# Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+clidir='/opt/sas/viya/home/bin/'
+debug=False
+
+# Import Python modules
+import argparse
+import sys
+
+from sharedfunctions import getpath
+
+# Define exception handler so that we only output trace info from errors when in debug mode
+def exception_handler(exception_type, exception, traceback, debug_hook=sys.excepthook):
+    if debug:
+        debug_hook(exception_type, exception, traceback)
+    else:
+        print "%s: %s" % (exception_type.__name__, exception)
+
+sys.excepthook = exception_handler
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-u","--objecturi", help="Object URI of folder or other object that can be contained within a folder.", required=True)
+parser.add_argument("-d","--debug", action='store_true', help="Debug")
+args = parser.parse_args()
+objecturi=args.objecturi
+debug=args.debug
+
+path=getpath(objecturi)
+
+if path is not None:
+    print path

--- a/listmembers.py
+++ b/listmembers.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# listmemberswithpath.py
+# January 2019
+#
+# Usage:
+# listmemberswithpath.py -u objectURI [-r] [-d]
+#
+# Examples:
+#
+# 1. Return list of members of a folder identified by objectURI
+#        ./listmemberswithpath.py -u /folders/folders/060c0ea4-07ee-43ea-aa79-a1696b7f8f52
+#
+# 2. Return list of all members of a folder identified by objectURI, recursively searching subfolders
+#        ./listmemberswithpath.py -u /folders/folders/060c0ea4-07ee-43ea-aa79-a1696b7f8f52 -r
+#
+# Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+clidir='/opt/sas/viya/home/bin/'
+debug=False
+
+# Import Python modules
+import argparse
+import sys
+
+from sharedfunctions import callrestapi,getpath
+
+# Define exception handler so that we only output trace info from errors when in debug mode
+def exception_handler(exception_type, exception, traceback, debug_hook=sys.excepthook):
+    if debug:
+        debug_hook(exception_type, exception, traceback)
+    else:
+        print "%s: %s" % (exception_type.__name__, exception)
+
+sys.excepthook = exception_handler
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-u","--objecturi", help="Object URI of folder or other object that can be contained within a folder.", required=True)
+parser.add_argument("-r","--recursive", action='store_true', help="Debug")
+parser.add_argument("-d","--debug", action='store_true', help="Debug")
+args = parser.parse_args()
+objecturi=args.objecturi
+recursive=args.recursive
+debug=args.debug
+
+#We expect a URI, but if the objectURI does not begin with a /, assume it is a folder id. This may be nonsense, but it's much more likely to just fail than return data for the wrong object.
+if not objecturi.startswith("/"):
+    objecturi='/folders/folders/'+objecturi
+
+#Exit if the objecURI is not a folder
+if not objecturi.startswith("/folders/folders/"):
+    raise Exception('ObjectURI must be a folder, and should begin with /folders/folders/.')
+
+#First, use the /folders/{folderId}/members endpoint to ask for a list of objects which are in the folder passed in by objecturi
+#See Folders API documentation in swagger at http://swagger.na.sas.com/apis/folders/v1/apidoc.html#op:getAncestors
+endpoint=objecturi+'/members'
+if recursive:
+    endpoint=endpoint+'?recursive=true'
+method='get'
+
+#make the rest call
+members_result_json=callrestapi(endpoint,method)
+
+if debug:
+    print(members_result_json)
+    #print('members_result_json is a '+type(members_result_json).__name__+' object') #members_result_json is a dict object
+
+members = members_result_json['items']
+
+for member in members:
+    outstr=''
+    path=getpath(member['uri'])
+    outstr=outstr+path+','+member['id']+','+member['name']+','+member['type']
+    if 'description' in member:
+        outstr=outstr+','+member['description']
+    else:
+        outstr=outstr+','
+    outstr=outstr+','+member['uri']
+    print outstr

--- a/sharedfunctions.py
+++ b/sharedfunctions.py
@@ -31,6 +31,7 @@
 #  28oct2018 Added stop on error to be able to override stopping processing when an error occurs
 #  20nov2018 Updated so that multiple profiles can be used
 #  20dec2018 Fixed standard csv output
+#  14JAN2019 Added getpath
 
 #
 # Copyright © 2018, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
@@ -575,3 +576,33 @@ def getprofileinfo(myprofile):
         
         
     
+# getpath
+# when a Viya objectURI is passed in return the path
+# change history
+#   14JAN2019 initial development
+
+def getpath(objecturi):
+
+    # build the request parameters
+    reqval='/folders/ancestors?childUri='+objecturi
+    reqtype='get'
+    accept='application/vnd.sas.content.folder.ancestor+json'
+
+    ancestors_result_json=callrestapi(reqval,reqtype,accept)
+    #print(ancestors_result_json)
+
+    if not 'ancestors' in ancestors_result_json:
+        print("NOTE: Could not get ancestor folders of ObjectURI '"+objecturi+"'.")
+        path=None
+    else:
+        ancestors = ancestors_result_json['ancestors']
+
+        path=''
+
+        #For each principle's section in the explanations section of the data returned from the REST API call...
+        for ancestor in ancestors:
+            path=ancestor['name']+'/'+path
+        path='/'+path
+
+    return path
+

--- a/unittestsadm34.sh
+++ b/unittestsadm34.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/sh
 #
-# unittestsadm33.sh
+# unittestsadm34.sh
 # December 2018
 #
 # Calls each of the pyviyatools at least once, as a simple unit/integration test

--- a/unittestsadm34.sh
+++ b/unittestsadm34.sh
@@ -179,3 +179,10 @@ id=$(grep "Id  " /tmp/folderid.txt | tr -s ' ' | cut -f3 -d " ")
 ./explainaccess.py -u /folders/folders/$id --header -p -c true
 echo
 
+echo "Get the path of a folder"
+./getpath.py -u /folders/folders/$id
+echo
+
+echo "List members of a folder, with paths for each member"
+./listmemberswithpath.py -u /folders/folders/$id -r
+echo


### PR DESCRIPTION
Added getpath.py which uses a new function getpath() in sharedfunctions.py, and listmemberswithpath.py which is similar to the text output of sas-admin folders list-members, but adds the path for each child object in a folder, and like the sas-admin folders list-members command, can recurse subfolders.

Also updated README.md to mention the two new tools, and updated unittestsadm34.sh to include example unit tests for the two new tools.

If you have the option when merging this with the master branch, it may be worth 'collapsing' the six commits I made in this branch into one commit, with the title of this merge request: Added getpath.py and listmemberswithpath.py. But I don't think it's a big deal either way.