### PR TITLE
Four new tools, replaced listcastables.py, fixed issue #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Additional tools provide more complex functionality by combining multiple calls 
 * **explainaccess.py** Explains access for a folder, object or service endpoint
 * **getpath.py** Return path of folder, report, or other object in folder
 * **listmemberswithpath.py** lists members of a folder, recursively if desired
+* **listcaslibs.py** Return list of all CAS libraries on all servers
+* **listcastables.py** Return list of all CAS tables in all CAS libraries on all servers
+* **listcaslibsandeffectiveaccess.py** Return list of all effective access on all CAS libraries on all servers
+* **listcastablesandeffectiveaccess.py** Return list of all effective access on all CAS tables in all CAS libraries on all servers
+* **listmemberswithpath.py** Return list of members of a folder identified by objectURI
+* **listgroupsandmembers.py** Return list of all groups and all their members
 
 Check back for additional tools and if you build a tool feel free to contribute it to the collection.
                    
@@ -245,6 +251,28 @@ FORMAT OF CSV file folder path (parents must exist), description
 
 \# Return list of all members of a folder identified by objectURI, recursively searching subfolders  
 *./listmemberswithpath.py -u /folders/folders/id -r*
+
+\# Return list of all CAS libraries on all servers
+*./listcaslibs.py*
+
+\# Return list of all CAS tables in all CAS libraries on all servers
+*./listcastables.py*
+
+\# Return list of all effective access on all CAS libraries on all servers
+*./listcaslibsandeffectiveaccess.py*
+
+\# Return list of all effective access on all CAS tables in all CAS libraries on all servers
+*./listcastablesandeffectiveaccess.py*
+
+\# Return list of members of a folder identified by objectURI
+*./listmemberswithpath.py -u /folders/folders/id*
+
+\# Return list of all members of a folder identified by objectURI, recursively searching subfolders
+*./listmemberswithpath.py -u /folders/folders/id -r*
+
+\# Return list of all groups and all their members
+*./listgroupsandmembers.py*
+
 
 **Troubleshooting**
 

--- a/README.md
+++ b/README.md
@@ -99,17 +99,16 @@ Additional tools provide more complex functionality by combining multiple calls 
 * **listrules.py** list authorization rules subset on a principal and/or a uri
 * **loginviauthinfo.py** use an authinfo file to authenticate to the CLI
 * **updateprefences.py** update preferences for a user or group of users
-* **updatedomain.py** Load a set of userids and passwords to a Viya domain from a csv file
-* **createfolders.py** Create a set of Viya folders from a csv file 
-* **explainaccess.py** Explains access for a folder, object or service endpoint
-* **getpath.py** Return path of folder, report, or other object in folder
+* **updatedomain.py** load a set of userids and passwords to a Viya domain from a csv file
+* **createfolders.py** create a set of Viya folders from a csv file 
+* **explainaccess.py** explains access for a folder, object or service endpoint
+* **getpath.py** return path of folder, report, or other object in folder
 * **listmemberswithpath.py** lists members of a folder, recursively if desired
-* **listcaslibs.py** Return list of all CAS libraries on all servers
-* **listcastables.py** Return list of all CAS tables in all CAS libraries on all servers
-* **listcaslibsandeffectiveaccess.py** Return list of all effective access on all CAS libraries on all servers
-* **listcastablesandeffectiveaccess.py** Return list of all effective access on all CAS tables in all CAS libraries on all servers
-* **listmemberswithpath.py** Return list of members of a folder identified by objectURI
-* **listgroupsandmembers.py** Return list of all groups and all their members
+* **listcaslibs.py** list all CAS libraries on all servers
+* **listcastables.py** list all CAS tables in all CAS libraries on all servers
+* **listcaslibsandeffectiveaccess.py** list all effective access on all CAS libraries on all servers
+* **listcastablesandeffectiveaccess.py** list all effective access on all CAS tables in all CAS libraries on all servers
+* **listgroupsandmembers.py** list all groups and all their members
 
 Check back for additional tools and if you build a tool feel free to contribute it to the collection.
                    
@@ -252,25 +251,25 @@ FORMAT OF CSV file folder path (parents must exist), description
 \# Return list of all members of a folder identified by objectURI, recursively searching subfolders  
 *./listmemberswithpath.py -u /folders/folders/id -r*
 
-\# Return list of all CAS libraries on all servers
+\# Return list of all CAS libraries on all servers  
 *./listcaslibs.py*
 
-\# Return list of all CAS tables in all CAS libraries on all servers
+\# Return list of all CAS tables in all CAS libraries on all servers  
 *./listcastables.py*
 
-\# Return list of all effective access on all CAS libraries on all servers
+\# Return list of all effective access on all CAS libraries on all servers  
 *./listcaslibsandeffectiveaccess.py*
 
-\# Return list of all effective access on all CAS tables in all CAS libraries on all servers
+\# Return list of all effective access on all CAS tables in all CAS libraries on all servers  
 *./listcastablesandeffectiveaccess.py*
 
-\# Return list of members of a folder identified by objectURI
+\# Return list of members of a folder identified by objectURI  
 *./listmemberswithpath.py -u /folders/folders/id*
 
-\# Return list of all members of a folder identified by objectURI, recursively searching subfolders
+\# Return list of all members of a folder identified by objectURI, recursively searching subfolders  
 *./listmemberswithpath.py -u /folders/folders/id -r*
 
-\# Return list of all groups and all their members
+\# Return list of all groups and all their members  
 *./listgroupsandmembers.py*
 
 

--- a/listcastables.py
+++ b/listcastables.py
@@ -1,16 +1,16 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# listcaslibs.py
+# listcastables.py
 # January 2019
 #
 # Usage:
-# listcaslibs.py [--noheader] [-d]
+# listcastables.py [--noheader] [-d]
 #
 # Examples:
 #
-# 1. Return list of all CAS libraries on all servers
-#        ./listcaslibs.py
+# 1. Return list of all CAS tables in all CAS libraries on all servers
+#        ./listcastables.py
 #
 # Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 #
@@ -52,8 +52,8 @@ debug=args.debug
 
 # Print header row unless noheader argument was specified
 if not noheader:
-    print('server,caslib')
-    
+    print('server,caslib,table')
+
 endpoint='/casManagement/servers'
 method='get'
 
@@ -68,6 +68,7 @@ servers = serverlist_result_json['items']
 
 for server in servers:
     servername=server['name']
+    #print(servername)
 
     # List the caslibs in this server
     endpoint='/casManagement/servers/'+servername+'/caslibs?excludeItemLinks=true'
@@ -79,4 +80,30 @@ for server in servers:
     caslibs=caslibs_result_json['items']
 
     for caslib in caslibs:
-        print(server['name']+','+caslib['name'])
+        caslibname=caslib['name']
+        #print('a: '+servername+','+caslibname)
+
+        # List the tables in the caslib
+        endpoint='/casManagement/servers/'+servername+'/caslibs/'+caslibname+'/tables?excludeItemLinks=true'
+        method='get'
+        #print('about to list tables')
+
+        tables_result_json=callrestapi(endpoint,method,stoponerror=False)
+
+        if debug:
+            print(tables_result_json)
+            print('tables_result_json is a '+type(tables_result_json).__name__+' object') #tables_result_json is a dict object
+        if tables_result_json is not None:
+            if tables_result_json['count']==0:
+                print(servername+','+caslibname+',[0 tables]')
+            if 'items' not in tables_result_json:
+                print(servername+','+caslibname+','+tables_result_json['message'])
+            else:
+                tables=tables_result_json['items']
+
+                for table in tables:
+                    tablename=table['name']
+                    print(servername+','+caslibname+','+tablename)
+        else:
+            #tables_result_json is None
+            print(servername+','+caslibname+',[error getting tables]')

--- a/listcastablesandeffectiveaccess.py
+++ b/listcastablesandeffectiveaccess.py
@@ -1,0 +1,130 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# listcastablesandeffectiveaccess.py
+# January 2019
+#
+# Usage:
+# listcastablesandeffectiveaccess.py [--noheader] [-d]
+#
+# Examples:
+#
+# 1. Return list of all effective access on all CAS tables in all CAS libraries on all servers
+#        ./listcastablesandeffectiveaccess.py
+#
+# Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the License);
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+debug=False
+
+
+# Import Python modules
+import argparse
+import sys
+from sharedfunctions import callrestapi
+
+# Define exception handler so that we only output trace info from errors when in debug mode
+def exception_handler(exception_type, exception, traceback, debug_hook=sys.excepthook):
+    if debug:
+        debug_hook(exception_type, exception, traceback)
+    else:
+        print "%s: %s" % (exception_type.__name__, exception)
+
+sys.excepthook = exception_handler
+
+identity_cols=['identity','identityType']
+permissions=['readInfo','select','limitedPromote','promote','createTable','dropTable','deleteSource','insert','update','delete','alterTable','alterCaslib','manageAccess']
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--noheader", action='store_true', help="Do not print the header row")
+parser.add_argument("-d","--debug", action='store_true', help="Debug")
+args = parser.parse_args()
+noheader=args.noheader
+debug=args.debug
+
+# Print header row unless noheader argument was specified
+if not noheader:
+    print('server,caslib,table,'+','.join(map(str, identity_cols))+','+','.join(map(str, permissions)))
+
+endpoint='/casManagement/servers'
+method='get'
+
+#make the rest call
+serverlist_result_json=callrestapi(endpoint,method)
+
+if debug:
+    print(serverlist_result_json)
+    print('serverlist_result_json is a '+type(serverlist_result_json).__name__+' object') #serverlist_result_json is a dict object
+
+servers = serverlist_result_json['items']
+
+for server in servers:
+    servername=server['name']
+
+    # List the caslibs in this server
+    endpoint='/casManagement/servers/'+servername+'/caslibs?excludeItemLinks=true'
+    method='get'
+    caslibs_result_json=callrestapi(endpoint,method)
+    if debug:
+        print(caslibs_result_json)
+        print('caslibs_result_json is a '+type(caslibs_result_json).__name__+' object') #caslibs_result_json is a dict object
+    caslibs=caslibs_result_json['items']
+
+    for caslib in caslibs:
+        caslibname=caslib['name']
+        #print(servername+','+caslibname)
+        
+        # Get the tables in the caslib
+        endpoint='/casManagement/servers/'+servername+'/caslibs/'+caslibname+'/tables?excludeItemLinks=true'
+        method='get'
+        #print('about to list tables')
+
+        tables_result_json=callrestapi(endpoint,method,stoponerror=False)
+
+        if debug:
+            print(tables_result_json)
+            print('tables_result_json is a '+type(tables_result_json).__name__+' object') #tables_result_json is a dict object
+        if tables_result_json is not None:
+            if tables_result_json['count']==0:
+                print(servername+','+caslibname+',[0 tables]')
+            if 'items' not in tables_result_json:
+                print(servername+','+caslibname+','+tables_result_json['message'])
+            else:
+                tables=tables_result_json['items']
+                for table in tables:
+                    tablename=table['name']
+                    # Get effective Access Controls on this table
+                    endpoint='/casAccessManagement/servers/'+servername+'/caslibs/'+caslibname+'/tableControls/'+tablename+'?accessControlType=effective'
+                    method='get'
+                    tableaccess_result_json=callrestapi(endpoint,method)
+
+                    #print(tableaccess_result_json)
+                    for ai in tableaccess_result_json['items']:
+                        output=servername+','+caslibname+','+tablename
+                        for col in identity_cols:
+                            if col in ai:
+                                 output=output+','+ai[col]
+                            else:
+                                 output=output+','
+                        for col in permissions:
+                            if col in ai:
+                                 output=output+','+ai[col]
+                            else:
+                                 output=output+','
+                        print output
+        else:
+            #tables_result_json is None
+            print(servername+','+caslibname+',[error getting tables]')
+        

--- a/listgroupsandmembers.py
+++ b/listgroupsandmembers.py
@@ -1,16 +1,16 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# listcaslibs.py
+# listgroupsandmembers.py
 # January 2019
 #
 # Usage:
-# listcaslibs.py [--noheader] [-d]
+# listgroupsandmembers.py [--noheader] [-d]
 #
 # Examples:
 #
-# 1. Return list of all CAS libraries on all servers
-#        ./listcaslibs.py
+# 1. Return list of all groups and all their members
+#        ./listgroupsandmembers.py
 #
 # Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 #
@@ -52,31 +52,40 @@ debug=args.debug
 
 # Print header row unless noheader argument was specified
 if not noheader:
-    print('server,caslib')
-    
-endpoint='/casManagement/servers'
+    print('groupid,groupname,grouptype,groupproviderid,memberid,membername,membertype,memberproviderid')
+
+endpoint='/identities/groups'
 method='get'
 
 #make the rest call
-serverlist_result_json=callrestapi(endpoint,method)
+groupslist_result_json=callrestapi(endpoint,method)
 
 if debug:
-    print(serverlist_result_json)
-    print('serverlist_result_json is a '+type(serverlist_result_json).__name__+' object') #serverlist_result_json is a dict object
+    print(groupslist_result_json)
+    print('groupslist_result_json is a '+type(groupslist_result_json).__name__+' object') #groupslist_result_json is a dict object
 
-servers = serverlist_result_json['items']
+groups = groupslist_result_json['items']
 
-for server in servers:
-    servername=server['name']
+for group in groups:
+    groupid=group['id']
+    groupname=group['name']
+    grouptype=group['type']
+    groupproviderid=group['providerId']
 
-    # List the caslibs in this server
-    endpoint='/casManagement/servers/'+servername+'/caslibs?excludeItemLinks=true'
+    # List the members of this group
+    endpoint='/identities/groups/'+groupid+'/members'
     method='get'
-    caslibs_result_json=callrestapi(endpoint,method)
+    members_result_json=callrestapi(endpoint,method)
     if debug:
-        print(caslibs_result_json)
-        print('caslibs_result_json is a '+type(caslibs_result_json).__name__+' object') #caslibs_result_json is a dict object
-    caslibs=caslibs_result_json['items']
+        print(members_result_json)
+        print('members_result_json is a '+type(members_result_json).__name__+' object') #members_result_json is a dict object
 
-    for caslib in caslibs:
-        print(server['name']+','+caslib['name'])
+    members=members_result_json['items']
+    
+    for member in members:
+        memberid=member['id']
+        membername=member['name']
+        membertype=member['type']
+        memberproviderid=member['providerId']
+
+        print(groupid+','+groupname+','+grouptype+','+groupproviderid+','+memberid+','+membername+','+membertype+','+memberproviderid)

--- a/listmemberswithpath.py
+++ b/listmemberswithpath.py
@@ -30,14 +30,11 @@
 #  limitations under the License.
 #
 
-
-clidir='/opt/sas/viya/home/bin/'
 debug=False
 
 # Import Python modules
 import argparse
 import sys
-
 from sharedfunctions import callrestapi,getpath
 
 # Define exception handler so that we only output trace info from errors when in debug mode

--- a/listrules.py
+++ b/listrules.py
@@ -8,6 +8,7 @@
 #
 # Change History
 # December 2018 - Added custom CSV output code, which writes out consistent columns in a specific order for the result rules JSON
+# January 2019 - Added 'id' to list of desired output columns
 #
 # Copyright © 2018, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 #
@@ -44,7 +45,7 @@ output_style=args.output
 limitval=10000
 
 # Define columns we want to output for each rule item (whether the item has a value for that column or not)
-desired_output_columns=['objectUri','containerUri','principalType','principal','setting','permissions','description','reason','createdBy','createdTimestamp','modifiedBy','modifiedTimestamp','condition','matchParams','mediaType','enabled','version']
+desired_output_columns=['objectUri','containerUri','principalType','principal','setting','permissions','description','reason','createdBy','createdTimestamp','modifiedBy','modifiedTimestamp','condition','matchParams','mediaType','enabled','version','id']
 valid_permissions=['read','update','delete','secure','add','remove','create']
 
 # build the request depending on what options were passed in

--- a/unittestsadm34.sh
+++ b/unittestsadm34.sh
@@ -36,9 +36,9 @@
 # 18Oct2018 updated gerrulid test because -o changed to -u 
 # 03Dec2018 Added tests for explainaccess.py
 # 23Jan2019 Added tests for six new tools (listcaslibs.py, listcastables.py,
-            listcaslibsandeffectiveaccess.py,
-            listcastablesandeffectiveaccess.py, listmemberswithpath.py,
-            listgroupsandmembers.py)
+#           listcaslibsandeffectiveaccess.py,
+#           listcastablesandeffectiveaccess.py, listmemberswithpath.py,
+#           listgroupsandmembers.py)
 #
 #
 # Copyright 2018, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.

--- a/unittestsadm34.sh
+++ b/unittestsadm34.sh
@@ -35,6 +35,10 @@
 # 01Jun2018 Initial version after refactoring tools
 # 18Oct2018 updated gerrulid test because -o changed to -u 
 # 03Dec2018 Added tests for explainaccess.py
+# 23Jan2019 Added tests for six new tools (listcaslibs.py, listcastables.py,
+            listcaslibsandeffectiveaccess.py,
+            listcastablesandeffectiveaccess.py, listmemberswithpath.py,
+            listgroupsandmembers.py)
 #
 #
 # Copyright 2018, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
@@ -185,4 +189,32 @@ echo
 
 echo "List members of a folder, with paths for each member"
 ./listmemberswithpath.py -u /folders/folders/$id -r
+echo
+
+echo "Return list of all CAS libraries on all servers"
+./listcaslibs.py
+echo
+
+echo "Return list of all CAS tables in all CAS libraries on all servers"
+./listcastables.py
+echo
+
+echo "Return list of all effective access on all CAS libraries on all servers"
+./listcaslibsandeffectiveaccess.py
+echo
+
+echo "Return list of all effective access on all CAS tables in all CAS libraries on all servers"
+./listcastablesandeffectiveaccess.py
+echo
+
+echo "Return list of members of a folder identified by objectURI"
+./listmemberswithpath.py -u /folders/folders/$id
+echo
+
+echo "Return list of all members of a folder identified by objectURI, recursively searching subfolders"
+./listmemberswithpath.py -u /folders/folders/$id -r
+echo
+
+echo "Return list of all groups and all their members"
+./listgroupsandmembers.py
 echo


### PR DESCRIPTION
Hi Gerry,

A bunch of changes in this pull request, as follows:

1. **Replaced old example listcaslibs.py with a new one** that is no longer a demo, but just lists all caslibs in all CAS servers, with a header, and no other details. This is a change I made sort of inadvertently, so if you care about the previous listcaslibs.py, we should REJECT this pull request and I'll go have them sit side-by-side. We should definitely discuss this before accepting this pull request.
2. **Four all-new tools**: listcastables.py, listcaslibsandeffectiveaccess.py, listcastablesandeffectiveaccess.py and listgroupsandmembers.py
3. Trivial change to listmemberswithpath.py, removing an unused variable clidir
4. Added 'id' to desired_output_columns in listrules.py, fixing issue #3 
5. Updates for the four new tools in README.md and unittestsadm34.sh, which ran without (unexpected) errors on my admin collection

Due to my inadvertent change to listcaslibs.py, let's chat when you have some time and decide whether to reverse that change and make a different tool, or just go with it.

David