### PR TITLE
Issue #83 - Adding a support for updating headers in requests.

### DIFF
--- a/callrestapi.py
+++ b/callrestapi.py
@@ -19,7 +19,7 @@
 # 08OCT2018 make printed json pretty 
 # 26OCT2018 call print function 
 # 20FEB2020 support simplejson
-
+# 16Jul2021 Support for updating the header. (Issue #83)
 
 #
 # Copyright © 2018, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
@@ -51,6 +51,7 @@ parser.add_argument("-a","--accepttype",help="Enter REST Content Type you want r
 parser.add_argument("-c","--contenttype",help="Enter REST Content Type for POST e.g application/vnd.sas.identity.basic+json",default="application/json")
 parser.add_argument("-o","--output", help="Output Style", choices=['csv','json','simple','simplejson'],default='json')
 parser.add_argument("-t","--text", help="Display Simple Text Results.", action='store_true')
+parser.add_argument("-hf","--headerfile",help="Enter the full path to a header json file",default=None)
 
 args = parser.parse_args()
 
@@ -61,15 +62,23 @@ reqcontent=args.contenttype
 reqaccept=args.accepttype
 simpletext=args.text
 output_style=args.output
+headfile=args.headerfile
 
 # keep for backward compatibility
 if simpletext: output_style='simple'
 
 # use the callrestapi function to make a call to the endpoint
 # call passing json or not
-if reqfile != None:
+if reqfile != None and headfile != None:
+    inputdata=getinputjson(reqfile)
+    headerdata=getinputjson(headfile)
+    result = callrestapi(reqval, reqtype, reqaccept, reqcontent, data=inputdata,header=headerdata)
+elif reqfile != None:
     inputdata=getinputjson(reqfile)
     result=callrestapi(reqval,reqtype,reqaccept,reqcontent,data=inputdata)
+elif headfile != None:
+    headerdata=getinputjson(headfile)
+    result=callrestapi(reqval,reqtype,reqaccept,reqcontent,header=headerdata)
 else:
     result=callrestapi(reqval,reqtype,reqaccept,reqcontent)
   

--- a/sharedfunctions.py
+++ b/sharedfunctions.py
@@ -34,6 +34,7 @@
 #  14JAN2019 Added getpath
 #  20SEP2019 Added getidsanduris
 #  09dec2020 Added get_valid_filename function to deal with invalid characters for Linux filesystem
+#  16Jul2021 Edited callrestapi to be able to update the header. (Issue #83)
 #
 # Copyright © 2018, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 #
@@ -88,8 +89,9 @@ def validaterestapi(baseurl, reqval, reqtype, data={}):
 # change history
 #   01dec2017 initial development
 #   28oct2018 Added stop on error to be able to override stopping processing when an error occurs
+#   16Jul2021 Added a functionality to update the header if necessary.
 
-def callrestapi(reqval, reqtype, acceptType='application/json', contentType='application/json',data={},stoponerror=1):
+def callrestapi(reqval, reqtype, acceptType='application/json', contentType='application/json',data={},header={},stoponerror=1):
 
 
     # get the url from the default profile
@@ -101,6 +103,9 @@ def callrestapi(reqval, reqtype, acceptType='application/json', contentType='app
     # build the authorization header
     head= {'Content-type':contentType,'Accept':acceptType}
     head.update({"Authorization" : oaval})
+    #Converting the header values to string to pass it into the header
+    header = {str(key):str(value) for key,value in header.items()}
+    head.update(header)
 
     # maybe this can be removed
     global result


### PR DESCRIPTION
Changed callrestapy.py - added another argument for users to add a header file, with the argument -hf. Added 3 if statements to take care of avarious conditions with regards to inputfile and header file. 

Changed sharedfunctions.py - Added another argument to callrestapi function. Changed the header to string to avoid any unicode character issues. 

