### PR TITLE
Fix/listmemberswithpath unicode support

### DIFF
--- a/listmemberswithpath.py
+++ b/listmemberswithpath.py
@@ -17,7 +17,7 @@
 #
 # Change History
 #
-# 09MAR2022 Python3 compatibility fix
+# 09MAR2022 Python3 compatibility fix, and better support output redirect to file in python2 with non-ASCII characters
 #
 #
 # Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
@@ -95,4 +95,7 @@ for member in members:
     else:
         outstr=outstr+','
     outstr=outstr+','+member['uri']
-    print(outstr)
+    try:
+        print(outstr)
+    except UnicodeEncodeError:
+        print(outstr.encode('ascii','replace'))

--- a/listmemberswithpath.py
+++ b/listmemberswithpath.py
@@ -15,6 +15,11 @@
 # 2. Return list of all members of a folder identified by objectURI, recursively searching subfolders
 #        ./listmemberswithpath.py -u /folders/folders/060c0ea4-07ee-43ea-aa79-a1696b7f8f52 -r
 #
+# Change History
+#
+# 09MAR2022 Python3 compatibility fix
+#
+#
 # Copyright © 2019, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 #
 #  Licensed under the Apache License, Version 2.0 (the License);
@@ -90,4 +95,4 @@ for member in members:
     else:
         outstr=outstr+','
     outstr=outstr+','+member['uri']
-    print outstr
+    print(outstr)


### PR DESCRIPTION
Put the final print(outstr) in a try: catch: block, so that if we are outputting to a destination (like redirecting to a file under python2) that does not support non-ASCII characters, replace them with ? (which stands in for the Unicode Replacement character � in ASCII output).

However, we try outputting the real utf-8 character first, so in all other circumstances - outputting to stdout in python2, and outputting to any destination in python3, it preserves the original characters.

