### PR TITLE
Dev/refreshtoken

### DIFF
--- a/getfolderid.py
+++ b/getfolderid.py
@@ -58,5 +58,5 @@ if output_style=='simple':
         print("Id  = "+targets[0])
         print("URI = "+targets[1])
         print("Path = "+targets[2])
-        print("CreatedBy = "+targets[3])
+        print("CreatedBy = "+targets[4])
 else: printresult(targets[4],output_style)

--- a/getfolderid.py
+++ b/getfolderid.py
@@ -59,4 +59,4 @@ if output_style=='simple':
         print("URI = "+targets[1])
         print("Path = "+targets[2])
         print("CreatedBy = "+targets[4])
-else: printresult(targets[4],output_style)
+else: printresult(targets[3],output_style)

--- a/savetoken.py
+++ b/savetoken.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Saves the access token from the CLI credentials file to a file in the format expected by the SAS Vscode extension
+# The token is saved to a file ~/.sas/<profile>_token.txt 
+#
+
+import sys
+import json
+import os
+
+from sharedfunctions import file_accessible, getprofileinfo 
+
+ #get authentication information for the header
+credential_file=os.path.join(os.path.expanduser('~'),'.sas','credentials.json')
+
+# check that credential file is available and can be read
+access_file=file_accessible(credential_file,'r')
+
+if access_file==False:
+    oaval=None
+    print("ERROR: Cannot read authentication credentials at: ", credential_file)
+    print("ERROR: Try refreshing your token with sas-admin auth login")
+    sys.exit()
+
+with open(credential_file) as json_file:
+    data = json.load(json_file)
+    
+# profile
+
+cur_profile=os.environ.get("SAS_CLI_PROFILE","NOTSET")
+
+if cur_profile=="NOTSET":
+    print("SAS_CLI_PROFILE environment variable not set, using Default profile")
+    cur_profile='Default'
+else:
+    print("SAS_CLI_PROFILE environment variable set to profile "+ cur_profile)
+
+
+ssl_file=os.environ.get("SSL_CERT_FILE","NOTSET")
+
+if ssl_file=="NOTSET":
+    print("SSL_CERT_FILE environment variable not set.")
+else:
+    print("SSL_CERT_FILE environment variable set to profile "+ ssl_file)
+
+
+r_ssl_file=os.environ.get("REQUESTS_CA_BUNDLE","NOTSET")
+
+if r_ssl_file=="NOTSET":
+    print("REQUESTS_CA_BUNDLE environment variable not set.")
+else:
+    print("REQUESTS_CA_BUNDLE environment variable set to profile "+ r_ssl_file)
+
+if cur_profile in data:
+
+    oauthToken=data[cur_profile]['access-token']
+    token_file=os.path.join(os.path.expanduser('~'),'.sas',cur_profile+"_token.txt")
+
+    with open(token_file, "w") as tokenfile:
+            tokenfile.write(oauthToken)
+    
+    print("NOTE: token saved to "+token_file)
+
+

--- a/sharedfunctions.py
+++ b/sharedfunctions.py
@@ -347,8 +347,9 @@ def getauthtoken(baseurl):
                 # write the new token to the credentials file
                 data[cur_profile]['access-token']=newtoken
                 
+                filecontent=json.dumps(data,indent=2)
                 with open(credential_file, "w") as outfile:
-                    outfile.write(data)
+                    outfile.write(filecontent)
 
         head= {'Content-type':'application/json','Accept':'application/json' }
         head.update({"Authorization" : oaval})

--- a/sharedfunctions.py
+++ b/sharedfunctions.py
@@ -206,7 +206,7 @@ def getfolderid(path):
         targeturi="/folders/folders/"+targetid
         targetcreatedBy=result['createdBy']
 
-    return [targetid,targeturi,targetname,targetcreatedBy,result]
+    return [targetid,targeturi,targetname,result,targetcreatedBy]
     
     
 

--- a/sharedfunctions.py
+++ b/sharedfunctions.py
@@ -346,6 +346,8 @@ def getauthtoken(baseurl):
 
                 # write the new token to the credentials file
                 data[cur_profile]['access-token']=newtoken
+
+                print(data)
                 
                 filecontent=json.dumps(data,indent=2)
                 with open(credential_file, "w") as outfile:


### PR DESCRIPTION
Use the CLI refresh token when the access token has expired.

For each request made, if the Viya access token is expired, the code will now get a new access token using the refresh token. In recent releases of Viya the access token only lasts for 1 hour. The refresh token is good for 90 days. 

Also in this merge fixed a bug created by a previous update to getfolderid function and tool. Unfortunately some other code depends on the full result dictionary being at index 3 of the returned result list.