### PR TITLE
rule replacement functionality

### DIFF
--- a/applyauthmodel.py
+++ b/applyauthmodel.py
@@ -13,13 +13,14 @@
 # Once an Auth Model Supplement document has been converted to csv files, that that collection of files
 # may be applied to a Viya environment using this script.
 #
-# Usage:
-# applyauthmodel.py -e <ENV> -d <DIR>
+# Usage examples:
+# applyauthmodel.py -e <ENV> -d <DIR> 
+# applyauthmodel.py -e <ENV> -d <DIR> --dryrun
+# applyauthmodel.py -e <ENV> -d <DIR> --dryrun --replacerules
 #
 # ENV refers to the same ENV value that was used for the extraction from the Supplement doc.
 # DIR refers to the directory that contains the csv files extracted.
-
-
+#
 import argparse, os, shutil
 
 # setup command-line arguements
@@ -27,11 +28,14 @@ parser = argparse.ArgumentParser(description="Applies the CSV files output by th
 parser.add_argument("-e","--env", help="Name of environment that is to be extracted.",required='True')
 parser.add_argument("-d","--directory", help="Directory that contains CSV auth files to be implemented.",required='True')
 parser.add_argument("--dryrun", help="Compiles commands for review without running them.",action='store_true')
+parser.add_argument("--replacerules", help="Changes the function of toggleviyarules call from \'disable\' to \'replace\' \
+                    - creating replacement rules for the Viya service account \'sasapp\'.",action='store_true')
 #parser.add_argument("-q","--quiet", help="Suppress the are you sure prompt when creating CASLIBs.", action='store_true')
 args = parser.parse_args()
 viyaenv=args.env
 indir=args.directory
 dryrun=args.dryrun
+reprules=args.replacerules
 #quietmode=args.quiet
 viyaglobal="ALL"
 cwd=os.getcwd()
@@ -192,7 +196,10 @@ else:
 ## Disable OOTB rules
 ## Uses "toggleviyarules.py" to read "ALL - Rules2Disable.csv"
 print("Disabling old rules...")
-command=os.path.join(cwd, 'toggleviyarules.py --skipfirstrow -o disable -f "')
+if not reprules:
+    command=os.path.join(cwd, 'toggleviyarules.py --skipfirstrow -o disable -f "')
+else:
+    command=os.path.join(cwd, 'toggleviyarules.py --skipfirstrow -o replace -p sasapp -ptype group -f "')
 csvfile=os.path.join(indir, viyaglobal+' - Rules2Disable.csv"')
 if not dryrun:
     os.system(command+csvfile)

--- a/toggleviyarules.py
+++ b/toggleviyarules.py
@@ -9,13 +9,32 @@
 #
 # 15May23 Initial development
 # 25May23 First release
+# 01AUG23 Major update - rule replacement functionality added
 #
-# Format of input csv file is 2 columns
+#
+# Basic Usage
+# >> Disables or enables rules read from a CSV file input.
+#
+# > Example:
+# toggleviyarules.py -f <input_csv.csv> -o {disable|enable}
+#
+#
+# Advanced Usage:
+# >> Disables rules read from a CSV file input, whilst skipping the first row,
+# >> then creates new copies (replacements) the same rules for a principal (user or group)
+# >> specified with the -p and -ptype flags.
+#
+# > Example:
+# toggleviyarules.py -f <input_csv.csv> -o replace -p <PRINCIPAL> -ptype <PRINCIPALTYPE> --skipfirstrow
+#
+#
+# Input CSV format requirements:
 # Column 1: Object URI
 # Column 2: Principal id [<groupID> | <userID> | "authenticatedUsers" | "guest" | "everyone"]
 #
-# For example:
+# >> Example:
 # "/jobExecution/jobRequests/*","authenticatedUsers"
+#
 #
 # Copyright 2023, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
 #
@@ -38,7 +57,7 @@ import subprocess
 import sys
 from sharedfunctions import callrestapi, getfolderid, file_accessible, printresult, getapplicationproperties
 
-## get cli location from properties
+## Get cli location from properties
 propertylist=getapplicationproperties()
 
 clidir=propertylist["sascli.location"]
@@ -46,28 +65,41 @@ cliexe=propertylist["sascli.executable"]
 clicommand=os.path.join(clidir,cliexe)
 
 
-## setup command-line arguements
+## Setup command-line arguements
 parser = argparse.ArgumentParser(description="Enables or Disables Viya rules in bulk.")
 parser.add_argument("-f","--file", help="Full path to CSV file. Format of csv: 'objecturi,principal",required='True')
-parser.add_argument("-o","--operator", help="Option to disable or enable rules", choices=['enable','disable'], required='True')
+parser.add_argument("-o","--operator", help="Option to enable, disable or replace rules", choices=['enable','disable','replace'], required='True')
 parser.add_argument("--skipfirstrow", help="Skip first row/header of the input csv file", action='store_true')
+parser.add_argument("-p","--princ", help="Requires operator option \'replace\'. Sets the principal (account/group) name to be used for the replacement copies of the rules being applied.")
+parser.add_argument("-ptype","--princtype", help="Requires operator option \'replace\'. Sets the principal TYPE to be used for the replacement copies of the rules being created and applied.", choices=['group','user','guest','authenticated-users','everyone'])
+
 
 args = parser.parse_args()
 file=args.file
-operator=args.operator
 skipfirstrow=args.skipfirstrow
+## Set new vars based on operator arg input
+if args.operator == 'replace':
+    operator='disable'
+    replaceop='replace'
+else:
+    operator=args.operator
+    replaceop="None"
 
 reqtype="post"
 check=file_accessible(file,'r')
 
 
-## Checks for previous unfinished or partial runs and clears tmp files
+## Checks for previous unfinished or partial runs and clears tmp or old files
 if os.path.exists('tmpcsv.csv'):
     os.remove('tmpcsv.csv')
 else: pass
 
 if os.path.exists('tmpcsv2.csv'):
     os.remove('tmpcsv2.csv')
+else: pass
+
+if os.path.exists("replacementrules.csv"):
+    os.remove("replacementrules.csv")
 else: pass
 
 
@@ -82,8 +114,11 @@ if check:
             objecturi=row[0]
             principal=row[1]
             with open('tmpcsv.csv', 'ab') as out:
-                command = subprocess.check_output(['./getruleid.py', '-u', objecturi, '-p', principal, '-o', 'csv'])
-                out.write(command)
+                commandcsv = subprocess.check_output(['./getruleid.py', '-u', objecturi, '-p', principal, '-o', 'csv'])
+                out.write(commandcsv)
+            with open('tmptxt.txt', 'ab') as out:
+                commandtxt = subprocess.check_output(['./getruleid.py', '-u', objecturi, '-p', principal, '-o', 'simple'])
+                out.write(commandtxt)
 
 
 ## Removes the header lines that are returned when getruleid.py is run
@@ -102,11 +137,7 @@ with open('tmpcsv2.csv') as input, open('ruleids.csv', "w") as output:
 print("Writing out bulk rule IDs to ruleids.csv")
 
 
-## Cleans up temporary files
-os.system('rm tmpcsv.csv tmpcsv2.csv')
-
-
-## Compiles and runs the Viya CLI commands to changes the rules' status
+## Compiles and runs the Viya CLI commands to change the rules' status
 with open("ruleids.csv", "r", newline='') as input:
     reader = csv.reader(input)
     for row in reader:
@@ -115,3 +146,76 @@ with open("ruleids.csv", "r", newline='') as input:
         print("Executing command: "+command)
         subprocess.call(command, shell=True)
 input.close()
+
+
+#### Optional sub-section for the 'replace' operator's functions
+if replaceop == 'replace': 
+
+    ## Validates arguments being parsed in
+    if args.princtype is None:
+        parser.error("When using --operator \'replace\' --princtype must also be set")
+
+    if args.princ is None and (args.princtype in ('group', 'user')):
+        parser.error("When using --princtype \'group\' or \'user\' a principal (user or group name) must be set using --princ")
+    elif args.princ is not None and (args.princtype in ('group', 'user')):
+        principaltype=args.princtype
+        replaceprinc=args.princ
+    else:
+        principaltype="--"+str(args.princtype)
+        replaceprinc=args.princ
+
+
+    ## Reads in the tmptxt.txt file created in earlier section, and formats the output into single rows
+    with open('tmptxt.txt') as rulesin, open ('tmptxt2.txt', 'w') as rulesout:
+        for line in rulesin:
+
+            if line.startswith(('condition', 'objectUri', 'permissions')):
+                if line.startswith("condition"):
+                    condition=line.replace('condition =  ','')
+                    condition=condition.replace('\n','')
+                    rulesout.write("found:"+f'"{condition}"'+',')
+                elif line.startswith("objectUri"):
+                    uri=line.strip("objectUri =  ").replace('\n','')
+                    rulesout.write(uri+',')           
+                elif line.startswith("permissions"):
+                    perms=line.strip("permissions =  ").replace(' ','')
+                    perms=perms.replace('\'','')
+                    perms=perms[1:-2]
+                    rulesout.write(f'"{perms}"\n')
+
+
+    ## Secondary if statements which reformat the rows produced in tmptxt2.txt
+    ## This is required to format the CSV with non-conditional (standard) rules.
+    with open('tmptxt2.txt') as rulesin2, open ('rulesout.txt', 'w') as rulesout2:
+        for line in rulesin2:
+            if line.startswith("found:"):
+                newline=line.replace("found:",'')
+                rulesout2.write(newline)
+            else:
+                rulesout2.write("\"\","+line)
+
+
+    ## Compiles the rulesout.txt file into a new CSV file in a format to be consumed by applyviyarules.py
+    with open ('rulesout.txt', 'r') as f:
+        newrules = csv.reader(f)
+        for row in newrules:
+            condition=f'"{row[0]}"'
+            objecturi=f'"{row[1]}"'
+            permissions=f'"{row[2]}"'
+            with open ('replacementrules.csv', 'a') as newcsv:
+                rule=objecturi+','+principaltype+','+replaceprinc+',grant,'+permissions+',True,'+condition+'\n'
+                newcsv.write(rule)
+            input.close()
+
+
+    ## Runs applyviyarules.py with CSV entries found in replacementrules.csv
+    applycommand = './applyviyarules.py '+'-f '+'replacementrules.csv'
+    subprocess.call(applycommand, shell=True)
+
+    
+    ## Cleans up tmp files created by this optional sub-section only
+    os.system('rm tmptxt2.txt rulesout.txt replacementrules.csv')
+
+
+## Cleans up tmp files
+os.system('rm tmpcsv.csv tmpcsv2.csv tmptxt.txt ruleids.csv')


### PR DESCRIPTION
toggleviyarules.py is now able to create substitute/replacement rules for rules which are being set to be disabled.
This is particularly useful when disabling OOTB assigned to Authenticated Users, yet functionality continues to be required (by service account "sasapp") for general Viya functionality.

The usage of this function would resemble this:
toggleviyarules.py -f <inputcsv.csv> -o replace -p sasapp -ptype group --skipfirstrow 