### PR TITLE
rule application fixes (#174)

### DIFF
--- a/applyviyarules.py
+++ b/applyviyarules.py
@@ -113,7 +113,7 @@ newrules='rulesapplied_'+runtime+'.csv'
 
 print("Checking for new rules to apply... \n")
 print("Printing results (CSV format) to: \033[1;34m"+newrules+"\033[0m \n")
-grepcom='grep -Fxiv -f existing_rules.csv '+ file + ' > '+newrules
+grepcom='grep -Fiv -f existing_rules.csv '+'"'+ file +'"' + ' > '+newrules
 subprocess.call(grepcom, shell=True)
 ##########################################################
 # End of Temporary section 1
@@ -139,14 +139,18 @@ try:
 except:
     print("There are \033[1;33mNO NEW RULES\033[0m to be applied. \n ")
 else:
+    mask= dfgrants['condition'] != ""
+    dfgrants= dfgrants[~mask]
     dfgrants.to_csv(newrules, header=False, index=None, quoting=csv.QUOTE_ALL)
     print("\033[1;32mFound",len(dfgrants),"\033[0mNEW RULE(S) to be applied \033[1;32mautomatically. \033[0m \n")
 
 try:
-    dfcondgrants= df2.get_group("conditional grant") 
+    dfcondgrants= df2.get_group("conditional grant")
 except:
     pass
 else:
+    mask= dfcondgrants['condition'] != ""
+    dfcondgrants= dfcondgrants[mask]
     dfcondgrants.to_csv(open(conditionalrules,'w'), header=False, index=None, quoting=csv.QUOTE_NONNUMERIC)
     print("\033[1;32mFound",len(dfcondgrants),"\033[0mNEW CONDITIONAL RULE(S) to be applied \033[1;31mmanually. \033[0m \n")
 

--- a/applyviyarules.py
+++ b/applyviyarules.py
@@ -7,19 +7,29 @@
 #
 # Change History
 #
-# 12Apr23 Initial development
+# 12Apr23  Initial development
+# 11Sept23 Major update - update to the way the script functions to accommodate current issues
+#          currently affecting Viya CLI.
+#          This script now runs a comparison of existing rules vs new rules being applied,
+#          so that only the delta from this comparison is submitted to Viya.
+#          (PMCPFR-1363)
+#          This script no longer applies rules with conditions attached to them, but issues
+#          a warning notifications and splits the rules to alternative CSV file for manual
+#          implementation.
+#          (PMCPFR-1364)
 #
 # Format of input csv file is 6 columns
 # Column 1: Object URI
 # Column 2: Principal type ["group" | "user"]
 # Column 3: Principal id [<groupID> | <userID>]
-# Column 4: Access setting ["grant" | "prohibit")
+# Column 4: Access grant type ["grant" | "conditional grant" | "prohibit")
 # Column 5: Applicable permissions ["read","delete","add","create","remove","secure","update"]
 # Column 6: Rule's status ["true" | "false"]
 # Column 7: Rule's condition, if applicable.
 #           This column must either be left blank OR contain a VALID SpEL condition.
 #           Use of an invalid condition will see the rule not be created in Viya.
 #           If unsure of a conditions validity, test it using the Viya EVM Rules interface.
+#           (NGMTS-30861)
 #
 # For example:
 # "/scoreExecution/executions/**","group","role_developer","grant","read,delete,create,secure,update",True,""
@@ -44,9 +54,13 @@ import os
 import json
 import subprocess
 import sys
+import re
+import pandas as pd
+from datetime import datetime
 from sharedfunctions import callrestapi, getfolderid, file_accessible, printresult, getapplicationproperties
 
-# get cli location from properties
+
+## get cli location from properties
 propertylist=getapplicationproperties()
 
 clidir=propertylist["sascli.location"]
@@ -54,7 +68,7 @@ cliexe=propertylist["sascli.executable"]
 clicommand=os.path.join(clidir,cliexe)
 
 
-# setup command-line arguements
+## setup command-line arguements
 parser = argparse.ArgumentParser(description="Apply bulk auths from a CSV file to folders and contents")
 parser.add_argument("-f","--file", help="Full path to CSV file. Format of csv: 'objecturi,principaltype,principalid,grant_or_prohibit,perms,enabled,condition",required='True')
 args = parser.parse_args()
@@ -64,11 +78,89 @@ reqtype="post"
 
 check=file_accessible(file,'r')
 constructed_bulk_rules_list=[]
+runtime = datetime.now().strftime("%Y%m%d_%H%M%S")
 
-## Checks that file can be read
+
+#newrules=file
+print('\napplyviyarules.py running...\n')
+
+##########################################################
+## Temporary section 1
+##########################################################
+## Runs a comparison of the file submitted by the user against existing_rules.csv
+## This section may be removed once PMCPFR-1363 is resolved.
+
+## Runs listrules.py and compiles exisiting_rules.csv
+print('Documenting existing rules... \n')
+existingrules = './listrules.py ' +'-o csv > existing_rules_verbose.csv'
+subprocess.call(existingrules, shell=True)
+
+#pd.set_option('display.max_columns', None)
+
+## Reads in and trims the existing_rules_verbose.csv file into existing_rules.csv
+df = pd.read_csv('existing_rules_verbose.csv',usecols=['objectUri','principalType','principal','setting','permissions','enabled','condition'])
+df['permissions']=df['permissions'].str[1:-1]
+df['permissions']=df['permissions'].str.replace(' ',',')
+df= df[['objectUri','principalType','principal','setting','permissions','enabled','condition']]
+df['enabled'] = df['enabled'].apply(lambda x:str(x))
+df.to_csv('existing_rules.csv', header=False, index=None, quoting=csv.QUOTE_NONNUMERIC)
+with open('existing_rules.csv', 'r') as exr:
+    csvrow = exr.readlines()
+    for line in csvrow:
+        rules=line.split("]") 
+
+newrules='rulesapplied_'+runtime+'.csv'
+
+print("Checking for new rules to apply... \n")
+print("Printing results (CSV format) to: \033[1;34m"+newrules+"\033[0m \n")
+grepcom='grep -Fxiv -f existing_rules.csv '+ file + ' > '+newrules
+subprocess.call(grepcom, shell=True)
+##########################################################
+# End of Temporary section 1
+##########################################################
+
+
+##########################################################
+# Temporary section 2
+##########################################################
+## Sorts the rules by 'grants' and 'conditional grants' and
+## send rules containing conditions to 'conditional_rules.csv'
+## for manual implementation.
+## This section may be removed once PMCPFR-1364 is resolved.
+conditionalrules='conditional_rules_'+runtime+'.csv'
+df2 = pd.read_csv(newrules, quoting=csv.QUOTE_ALL, names=['objectUri','principalType','principal','setting','permissions','enabled','condition'])
+df2.sort_values(by=['setting'],inplace=True, ascending=False)
+df2= df2.fillna("")
+df2= df2.groupby('setting')
+dfgrants=None
+dfcondgrants=None
+try:
+    dfgrants= df2.get_group("grant")
+except:
+    print("There are \033[1;33mNO NEW RULES\033[0m to be applied. \n ")
+else:
+    dfgrants.to_csv(newrules, header=False, index=None, quoting=csv.QUOTE_ALL)
+    print("\033[1;32mFound",len(dfgrants),"\033[0mNEW RULE(S) to be applied \033[1;32mautomatically. \033[0m \n")
+
+try:
+    dfcondgrants= df2.get_group("conditional grant") 
+except:
+    pass
+else:
+    dfcondgrants.to_csv(open(conditionalrules,'w'), header=False, index=None, quoting=csv.QUOTE_NONNUMERIC)
+    print("\033[1;32mFound",len(dfcondgrants),"\033[0mNEW CONDITIONAL RULE(S) to be applied \033[1;31mmanually. \033[0m \n")
+
+if dfgrants is None and dfcondgrants is None :
+    sys.exit()
+##########################################################
+# End of Temporary section 2
+##########################################################
+
+
+## Loops through the 'newrules' file and converts the CSV rows into JSON entries
 if check:
-    with open(file, 'rt') as f:
-        filecontents = csv.reader(f)
+    with open(newrules, 'r') as f:
+        filecontents = csv.reader(f, skipinitialspace=True)
         for row in filecontents:
             objecturi=row[0]
             principaltype=row[1]
@@ -77,12 +169,17 @@ if check:
             perms=row[4]
             enabled=row[5]
             condition=row[6]
+            pattern=str(row)[1:-1]
+            pattern=f'{pattern}'
 
-            print("Creating auth rules for "+objecturi)
+            ## debug ##
+            #print('printing pattern: = '+pattern)
+            #print("Creating auth rules for "+objecturi)
 
             reqval=objecturi
+        
 
-## Construct JSON objects from auth rules defined in CSV.
+            ## Construct JSON objects from auth rules defined in CSV
             value_dict_object={"description":"Created by applyviyarules.py",
                         "objectUri":reqval,
                         "permissions":perms.split(','),
@@ -103,14 +200,66 @@ if check:
 else:
     print("ERROR: cannot read "+file)
 
-print("Writing out bulk rule JSON file to bulk_rules_list.json")
+## This if/else statement can be removed and the following section dedented
+## once PMCPFR-1364 is resolved.
+if dfgrants is not None:
+    newrulesjson='rulesapplied_'+runtime+'.json'
+    print("Printing new rules (JSON format) to: \033[1;34m" +newrulesjson+" \033[0m \n")
 
-# Construct JSON schema containing rules
-bulk_rules_list_string=json.dumps(constructed_bulk_rules_list,indent=2)
-with open("bulk_rules_list.json", "w") as text_file:
-    text_file.write(bulk_rules_list_string+'\n')
+    ## Construct JSON schema containing rules
+    bulk_rules_list_string=json.dumps(constructed_bulk_rules_list,indent=2)
+    with open(newrulesjson, "w") as text_file:
+        text_file.write(bulk_rules_list_string+'\n')
 
-# Execute sas-admin CLI to apply rules from JSON schema
-command=clicommand+' authorization create-rules --file bulk_rules_list.json'
-print("Executing command: "+command)
-subprocess.call(command, shell=True)
+    ## Execute sas-admin CLI to apply rules from JSON schema
+    command=clicommand+' authorization create-rules --file '+newrulesjson
+    print("Applying new rules...\n")
+    print("Executing command: "+command)
+    subprocess.call(command, shell=True)
+
+else:
+    pass
+
+##########################################################
+# Temporary section 3
+##########################################################
+## Prints a note to inform the user that the conditional
+## rules have been output to a CSV file and NOT applied.
+## This section may be removed once PMCPFR-1364 is resolved.
+if dfcondgrants is not None:
+    print(
+     '''
+     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+     !!!                                    !!!
+     !!!\033[1;31m    IMPORTANT NOTE - PLEASE READ\033[0m    !!!
+     !!!                                    !!!
+     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+     Due to a known issue currently affecting
+     the Viya CLI, it is recommended that all
+     Viya rules that include a condition/
+     conditional grant, be implemented manually
+     through SAS Environment Manager interface.
+
+     A list of rules for manual implementation
+     has been output to:
+
+     ''')
+    print('     \033[1;33m'+conditionalrules+'\033[0m')
+    print(
+     '''
+
+     (September 2023 - PMCPFR-1364)
+
+     '''
+              )
+else:
+    print("\n\033[1;33mNo conditional rules found in: "+file+"\033[0m")
+##########################################################
+# End of Temporary section 3
+##########################################################
+
+## Cleans up tmp files
+try:
+    os.system('rm existing_rules.csv existing_rules_verbose.csv')
+except:
+    pass

--- a/listrules.py
+++ b/listrules.py
@@ -46,7 +46,8 @@ limitval=10000
 
 # Define columns we want to output for each rule item (whether the item has a value for that column or not)
 desired_output_columns=['objectUri','containerUri','principalType','principal','setting','permissions','description','reason','createdBy','createdTimestamp','modifiedBy','modifiedTimestamp','condition','matchParams','mediaType','enabled','version','id']
-valid_permissions=['read','update','delete','secure','add','remove','create']
+#valid_permissions=['read','update','delete','secure','add','remove','create']
+valid_permissions=['remove','read','update','create','delete','add','secure']
 
 # build the request depending on what options were passed in
 if ident.lower()=='authenticatedusers': ident='authenticatedUsers'

--- a/listrules.py
+++ b/listrules.py
@@ -46,8 +46,7 @@ limitval=10000
 
 # Define columns we want to output for each rule item (whether the item has a value for that column or not)
 desired_output_columns=['objectUri','containerUri','principalType','principal','setting','permissions','description','reason','createdBy','createdTimestamp','modifiedBy','modifiedTimestamp','condition','matchParams','mediaType','enabled','version','id']
-#valid_permissions=['read','update','delete','secure','add','remove','create']
-valid_permissions=['remove','read','update','create','delete','add','secure']
+valid_permissions=['read','update','delete','secure','add','remove','create']
 
 # build the request depending on what options were passed in
 if ident.lower()=='authenticatedusers': ident='authenticatedUsers'

--- a/toggleviyarules.py
+++ b/toggleviyarules.py
@@ -150,6 +150,8 @@ input.close()
 
 #### Optional sub-section for the 'replace' operator's functions
 if replaceop == 'replace': 
+    
+
 
     ## Validates arguments being parsed in
     if args.princtype is None:
@@ -164,6 +166,9 @@ if replaceop == 'replace':
         principaltype="--"+str(args.princtype)
         replaceprinc=args.princ
 
+    ## Formats variables with quotes, required for delta checking in applyviyarules.py
+    replaceprinc=f'"{replaceprinc}"'
+    principaltype=f'"{principaltype}"'
 
     ## Reads in the tmptxt.txt file created in earlier section, and formats the output into single rows
     with open('tmptxt.txt') as rulesin, open ('tmptxt2.txt', 'w') as rulesout:
@@ -202,8 +207,12 @@ if replaceop == 'replace':
             condition=f'"{row[0]}"'
             objecturi=f'"{row[1]}"'
             permissions=f'"{row[2]}"'
+            if condition == "\"\"":
+                grant_type = '"grant"'
+            else:
+                grant_type = '"conditional grant"'
             with open ('replacementrules.csv', 'a') as newcsv:
-                rule=objecturi+','+principaltype+','+replaceprinc+',grant,'+permissions+',True,'+condition+'\n'
+                rule=objecturi+','+principaltype+','+replaceprinc+','+grant_type+','+permissions+',"True",'+condition+'\n'
                 newcsv.write(rule)
             input.close()
 


### PR DESCRIPTION
Workarounds implemented to:
applyviyarules.py
toggleviyarules.py

Change made to listrules.py in 'patches (#174)' commit, which was then rolled back in 'rule application fixes (#174)' commit.

TLDR: Changes should remedy issues where Viya CLI is stops applying rules when it encounters a rule that's either identical or only has a distinct condition.

Description:
Update to applyviyarules.py which now sees the script extract a list of existing rules from Viya and compare (using grep) the extracted rules vs the rules being applied. If the rule already exists it is discarded, if it new it is then automatically created.

If it is a new rule but contains a condition, then it is sent to an alternative csv to be manually created in the Viya env, as currently, creation of conditional rules using the CLI encounters a bug.