### PR TITLE
Test list numbering correction

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,7 +83,7 @@ pip install -r requirements.txt
 ./callrestapi.py -e /folders/folders -m get*
 ```
 
-2. To see the current setup, including python and package versions, environment variable settings, profile information and current user. Run
+3. To see the current setup, including python and package versions, environment variable settings, profile information and current user. Run
 
 ```sh
 ./showsetup.py


### PR DESCRIPTION
Due to the fact that there's an un-indented code block between steps 2 and 3 of the Test, the numbering of the list doesn't continue.

Corrected this by statically setting item #3 to "3.", as it's a less significant change than indenting the code block(s).