### PR TITLE
Add UploadFiles Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ The file sharedfunctions.py contains a set of generic functions that make it eas
 * acceptType: optinal accept type content header
 * contentType: optional content type content header
 * data: optionally a python dictionary created from the json for the rest request
+* params: optional dictionary of query parameters to pass to the rest request
 * stoponerror: whether the function will stop all further processing if an error occurs (default 0 to not stop)
 
 We suggest you use [listcaslibs_example.py](listcaslibs_example.py) as a simple example to copy from if you wish to develop your own python scripts, and are new to Python or some of the concepts we have used. If one of the other existing tools is similar to what you want, of course you could use that as the basis for a new tool too.

--- a/sharedfunctions.py
+++ b/sharedfunctions.py
@@ -108,7 +108,7 @@ def validaterestapi(baseurl, reqval, reqtype, data={}):
 #   15DEC2022 Added noprint, can be used to suppress the printing of the error messages when stoponerror is disabled, defaults to print for compatibility
 
 
-def callrestapi(reqval, reqtype, acceptType='application/json', contentType='application/json',data={},header={},stoponerror=1,returnEtag=False,etagIn='',noprint=0):
+def callrestapi(reqval, reqtype, acceptType='application/json', contentType='application/json',data={},header={},params={},stoponerror=1,returnEtag=False,etagIn='',noprint=0):
 
 
     # get the url from the default profile
@@ -132,15 +132,18 @@ def callrestapi(reqval, reqtype, acceptType='application/json', contentType='app
     # maybe this can be removed
     global result
 
-    # serialize the data string for the request to json format
-    json_data=json.dumps(data, ensure_ascii=True)
+    # Serialize non-multipart payloads as json. Multipart requests pass raw files via
+    # the requests "files" argument and must not be json-serialized.
+    json_data=None
+    if reqtype!="postmultipart":
+        json_data=json.dumps(data, ensure_ascii=True)
 
-    #convert if python 2
-    # get python version
-    # if we don't do this any request with foreign characters fails
-    version=int(str(sys.version_info[0]))
-    #if version==2: json_data = json_data.encode(encoding='utf-8')
-    json_data.encode(encoding='utf-8')
+        #convert if python 2
+        # get python version
+        # if we don't do this any request with foreign characters fails
+        version=int(str(sys.version_info[0]))
+        #if version==2: json_data = json_data.encode(encoding='utf-8')
+        json_data.encode(encoding='utf-8')
 
     # call the rest api using the parameters passed in and the requests python library
 
@@ -154,17 +157,26 @@ def callrestapi(reqval, reqtype, acceptType='application/json', contentType='app
         verify_ssl=True
 
     if reqtype=="get":
-        ret = requests.get(baseurl+reqval,headers=head,data=json_data,verify=verify_ssl)
+        ret = requests.get(baseurl+reqval,headers=head,data=json_data, params=params, verify=verify_ssl)
     elif reqtype=="post":
-        ret = requests.post(baseurl+reqval,headers=head,data=json_data,verify=verify_ssl)       
+        ret = requests.post(baseurl+reqval,headers=head,data=json_data, params=params, verify=verify_ssl)
     elif reqtype=="delete":
-        ret = requests.delete(baseurl+reqval,headers=head,data=json_data,verify=verify_ssl)
+        ret = requests.delete(baseurl+reqval,headers=head,data=json_data, params=params, verify=verify_ssl)
     elif reqtype=="put":
-        ret = requests.put(baseurl+reqval,headers=head,data=json_data,verify=verify_ssl)
+        ret = requests.put(baseurl+reqval,headers=head,data=json_data, params=params, verify=verify_ssl)
     elif reqtype=="patch":
-        ret = requests.patch(baseurl+reqval,headers=head,data=json_data,verify=verify_ssl)
+        ret = requests.patch(baseurl+reqval,headers=head,data=json_data, params=params, verify=verify_ssl)
     elif reqtype=="head":
-        ret = requests.head(baseurl+reqval,headers=head,data=json_data,verify=verify_ssl)
+        ret = requests.head(baseurl+reqval,headers=head,data=json_data, params=params, verify=verify_ssl)
+    elif reqtype=="postmultipart":
+        # The requests package will use multipart if we use the "files" parameter instead of the "data" parameter, and we need to use that for file uploads. 
+        # This should take care of adding the necessary content-type header for multipart with the boundary and also properly format the body of the request for multipart. 
+        # The content-disposition header with the filename is added in the header parameter when this function is called.
+        if "Content-type" in head:
+            del head["Content-type"]
+        if "content-type" in head:
+            del head["content-type"]
+        ret = requests.post(baseurl+reqval,headers=head,files=data, params=params, verify=verify_ssl)
     else:
         result=None
         print("NOTE: Invalid method")

--- a/sharedfunctions.py
+++ b/sharedfunctions.py
@@ -135,7 +135,13 @@ def callrestapi(reqval, reqtype, acceptType='application/json', contentType='app
     # Serialize non-multipart payloads as json. Multipart requests pass raw files via
     # the requests "files" argument and must not be json-serialized.
     json_data=None
-    if reqtype!="postmultipart":
+    if reqtype in ["postmultipart","putmultipart"]:
+        json_data=None
+        if "Content-type" in head:
+            del head["Content-type"]
+        if "content-type" in head:
+            del head["content-type"]
+    else:
         json_data=json.dumps(data, ensure_ascii=True)
 
         #convert if python 2
@@ -169,14 +175,9 @@ def callrestapi(reqval, reqtype, acceptType='application/json', contentType='app
     elif reqtype=="head":
         ret = requests.head(baseurl+reqval,headers=head,data=json_data, params=params, verify=verify_ssl)
     elif reqtype=="postmultipart":
-        # The requests package will use multipart if we use the "files" parameter instead of the "data" parameter, and we need to use that for file uploads. 
-        # This should take care of adding the necessary content-type header for multipart with the boundary and also properly format the body of the request for multipart. 
-        # The content-disposition header with the filename is added in the header parameter when this function is called.
-        if "Content-type" in head:
-            del head["Content-type"]
-        if "content-type" in head:
-            del head["content-type"]
         ret = requests.post(baseurl+reqval,headers=head,files=data, params=params, verify=verify_ssl)
+    elif reqtype=="putmultipart":
+        ret = requests.put(baseurl+reqval,headers=head,files=data, params=params, verify=verify_ssl)
     else:
         result=None
         print("NOTE: Invalid method")

--- a/uploadfiles.py
+++ b/uploadfiles.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Script to add one or more files to the files service in the Viya environment.
+# This uses the files service rest API to upload files, so is bound by the configured size limit for the files service.
+# Script will accept as arguments a destination path in SAS Content and either one or more files to upload, or a folder containing files to upload.
+# The script is provided either multiple --file arguments or a single --folder argument, or both. It is also passed a --content-path argument which is the destination path in SAS Content where the files will be uploaded to.
+# Change History
+# 27MAY2026 Initial commit
+#
+import argparse
+import os
+from sharedfunctions import callrestapi,getfolderid,getpath
+import logging
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-f","--file", help="Specify one or more files to upload.",action="append")
+parser.add_argument("--folder", help="Specify a folder containing files to upload.")
+parser.add_argument("-c","--content-path", help="Specify the destination path in SAS Content where the files will be uploaded to.",required=True)
+args = parser.parse_args()
+files=args.file
+folder=args.folder
+content_path=args.content_path
+
+# set up logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# Validate that at least one of --file or --folder is provided
+if not files and not folder:
+    logging.error("You must specify at least one file to upload or a folder containing files to upload.")
+    exit(1)
+
+# Get the folder ID for the destination content path
+folder_details = getfolderid(content_path)
+folder_id = folder_details[0]
+if not folder_id:
+    logging.error(f"Could not find folder ID for content path: {content_path}")
+    exit(1)
+
+# Collect the list of files to upload
+files_to_upload = []
+if files:
+    for file in files:
+        if os.path.isfile(file):
+            files_to_upload.append(file)
+        else:
+            logging.warning(f"Specified file does not exist: {file}")
+if folder:
+    if os.path.isdir(folder):
+        for entry in os.listdir(folder):
+            file_path = os.path.join(folder, entry)
+            if os.path.isfile(file_path):
+                files_to_upload.append(file_path)
+    else:
+        logging.warning(f"Specified folder does not exist: {folder}")
+
+if not files_to_upload:
+    logging.error("No valid files to upload.")
+    exit(1)
+
+
+# For each file, call the files service endpoint (POST to /files/files) using multipart or the body to upload the file content. Use the content-disposition header to specify the file name. 
+# The query parameter parentFolderUri should be set to /folders/folders/{folder_id} where folder_id is the ID of the destination folder in SAS Content we want to upload the file to.
+# The query parameter typeDefName is used to specify the type of the file being uploaded. We can check if /types/types/file_{extension} exists to determine if there is a specific type for the file extension, and if not we can not define the typeDefName parameter and the files service will default to treating it as a generic file.
+
+# Maintain a list of extensions we have checked for a specific type definition to avoid making unnecessary REST API calls.
+checked_extensions = {}
+
+for file in files_to_upload:
+    file_name = os.path.basename(file)
+    file_extension = os.path.splitext(file_name)[1].lower().lstrip('.')
+    type_def_name = None
+
+    if file_extension in checked_extensions:
+        type_def_name = checked_extensions[file_extension]
+    else:
+        # Check if a specific type definition exists for this file extension using HEAD method on /types/types/file_{extension}
+        type_check_response,type_check_response_code = callrestapi(f"/types/types/file_{file_extension}", "head")
+        if type_check_response_code == 200:
+            type_def_name = f"file_{file_extension}"
+            logging.info(f"Found specific type definition for extension '{file_extension}': {type_def_name}")
+        else:
+            logging.info(f"No specific type definition found for extension '{file_extension}'. Using generic file type.")
+        checked_extensions[file_extension] = type_def_name
+
+    with open(file, 'rb') as f:
+        files_payload = {
+            'file': (file_name, f)
+        }
+        query_params = {
+            'parentFolderUri': f"/folders/folders/{folder_id}"
+        }
+        if type_def_name:
+            query_params['typeDefName'] = type_def_name
+
+        response = callrestapi("/files/files", "postmultipart", data=files_payload, params=query_params)
+        if response and response.get("id"):
+            logging.info(f"Successfully uploaded file: {file_name}")
+        else:
+            logging.error(f"Failed to upload file: {file_name}")

--- a/uploadfiles.py
+++ b/uploadfiles.py
@@ -6,6 +6,9 @@
 # Change History
 # 27MAY2026 Initial commit
 #
+# Copyright © 2026, SAS Institute Inc., Cary, NC, USA.  All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 import argparse
 import os
 from sharedfunctions import callrestapi,getfolderid,getpath

--- a/uploadfiles.py
+++ b/uploadfiles.py
@@ -96,13 +96,7 @@ for file in files_to_upload:
                 files_payload = {
                     'file': (file_name, f)
                 }
-                query_params = {
-                    'parentFolderUri': f"/folders/folders/{folder_id}"
-                }
-                if type_def_name:
-                    query_params['typeDefName'] = type_def_name
-
-                response = callrestapi(f"{file_uri}/content", "putmultipart", data=files_payload, params=query_params, header=headers)
+                response = callrestapi(f"{file_uri}/content", "putmultipart", data=files_payload, header=headers)
                 if response and response.get("id"):
                     logging.info(f"Successfully overwritten file: {file_name}")
                 else:

--- a/uploadfiles.py
+++ b/uploadfiles.py
@@ -11,12 +11,13 @@
 
 import argparse
 import os
-from sharedfunctions import callrestapi,getfolderid,getpath
+from sharedfunctions import callrestapi,getfolderid
 import logging
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-f","--file", help="Specify one or more files to upload.",action="append")
 parser.add_argument("--folder", help="Specify a folder containing files to upload.")
+parser.add_argument("-w","--overwrite", help="Overwrite existing files with the same name in the destination folder.",action="store_true")
 parser.add_argument("-c","--content-path", help="Specify the destination path in SAS Content where the files will be uploaded to.",required=True)
 args = parser.parse_args()
 files=args.file
@@ -60,28 +61,66 @@ if not files_to_upload:
     exit(1)
 
 
-# For each file, call the files service endpoint (POST to /files/files) using multipart or the body to upload the file content. Use the content-disposition header to specify the file name. 
-# The query parameter parentFolderUri should be set to /folders/folders/{folder_id} where folder_id is the ID of the destination folder in SAS Content we want to upload the file to.
-# The query parameter typeDefName is used to specify the type of the file being uploaded. We can check if /types/types/file_{extension} exists to determine if there is a specific type for the file extension, and if not we can not define the typeDefName parameter and the files service will default to treating it as a generic file.
+# For each file, call the files service endpoint (POST to /files/files) using multipart or the body to upload the file content.
+# The query parameter parentFolderUri should be set to /folders/folders/{folder_id} where folder_id is the ID of the destination folder in SAS Content.
+# The query parameter typeDefName is used to specify the type of the file being uploaded from the types service.
 
 # Maintain a list of extensions we have checked for a specific type definition to avoid making unnecessary REST API calls.
 checked_extensions = {}
-
+ 
 for file in files_to_upload:
     file_name = os.path.basename(file)
     file_extension = os.path.splitext(file_name)[1].lower().lstrip('.')
     type_def_name = None
 
+    # Check if a file with this name already exists in the destination folder
+    response = callrestapi(f"/folders/folders/{folder_id}/members", "get", params={"filter": f"and(eq(name,'{file_name}'),eq(type,'child'))"})
+    if response and response.get("items"): # We have at least one file with this name in the destination folder
+        if args.overwrite:
+            # Check if it's only one file with this name in the destination folder. If there are multiple, we will not overwrite and will log a warning.
+            if len(response["items"]) > 1:
+                logging.warning(f"Multiple files with the name '{file_name}' already exist in the destination folder. Skipping upload.")
+                continue
+            logging.info(f"A file with the name '{file_name}' already exists in the destination folder. Overwriting.")
+            # We can overwrite using a PUT request to /files/files/{file_id}/content.
+            file_uri = response["items"][0]["uri"]
+            # Get the etag of the existing file to include in the If-Match header for the PUT request.
+            response,etag,rc = callrestapi(file_uri, "head", returnEtag=True)
+            if not etag:
+                logging.error(f"Could not retrieve etag for existing file: {file_name}. Skipping upload.")
+                continue
+            headers = {
+                "If-Match": etag
+            }
+            with open(file, 'rb') as f:
+                files_payload = {
+                    'file': (file_name, f)
+                }
+                query_params = {
+                    'parentFolderUri': f"/folders/folders/{folder_id}"
+                }
+                if type_def_name:
+                    query_params['typeDefName'] = type_def_name
+
+                response = callrestapi(f"{file_uri}/content", "putmultipart", data=files_payload, params=query_params, header=headers)
+                if response and response.get("id"):
+                    logging.info(f"Successfully overwritten file: {file_name}")
+                else:
+                    logging.error(f"Failed to overwrite file: {file_name}")
+            continue
+        else:
+            logging.warning(f"A file with the name '{file_name}' already exists in the destination folder. Skipping upload.")
+            continue
+
     if file_extension in checked_extensions:
         type_def_name = checked_extensions[file_extension]
     else:
-        # Check if a specific type definition exists for this file extension using HEAD method on /types/types/file_{extension}
-        type_check_response,type_check_response_code = callrestapi(f"/types/types/file_{file_extension}", "head")
-        if type_check_response_code == 200:
-            type_def_name = f"file_{file_extension}"
-            logging.info(f"Found specific type definition for extension '{file_extension}': {type_def_name}")
+        # Check if a specific type definition exists for this file extension using /types/types?filter=contains(extensions,'{file_extension}')
+        response = callrestapi("/types/types", "get", params={"filter": f"contains(extensions,'{file_extension}')"})
+        if response and response.get("items"):
+            type_def_name = response["items"][0]["name"]
         else:
-            logging.info(f"No specific type definition found for extension '{file_extension}'. Using generic file type.")
+            logging.info(f"No specific type definition found for file extension: {file_extension}")
         checked_extensions[file_extension] = type_def_name
 
     with open(file, 'rb') as f:


### PR DESCRIPTION
This PR adds a new tool, uploadfiles.py to upload one or more files to the SAS Content in Viya. 

The tool makes use of the files service API:
[createNewFileMultiPart](https://developer.sas.com/rest-apis/files/createNewFileMultiPart)
[updateFileContent](https://developer.sas.com/rest-apis/files/updatedFileContent)

Summary of changes:
- Add a "params" option to the callrestapi sharedfunction to support query parameters more cleanly.
- Add "postmultipart" and "putmultipart" methods to the callrestapi sharedfunction.
- Add the uploadfiles.py tool.

Usage: 
```
uploadfiles.py --file /path/to/file1.ext [--file /path/to/file2.ext] [--folder /path/to/multiple/files] --content-path "/Public/Uploads"
```

Functionality:
- Resolve the supplied content folder to a URI using the getfolderid function.
- For each unique extension, check if a type is defined by calling /types/types/file_ext
- Check if a file already exists in the path with that name
- If so, optionally overwrite it with updateFileContent or skip the file
- If not, create the file using createNewFileMultiPart